### PR TITLE
Fix CI build for rustler

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -56,16 +56,16 @@ jobs:
     # Step: Define how to cache the `_build` directory. After the first run,
     # this speeds up tests runs a lot. This includes not re-compiling our
     # project's downloaded deps every run.
-    - name: Cache compiled build
-      id: cache-build
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-compiled-build
-      with:
-        path: _build
-        key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-mix-${{ env.cache-name }}-
+#    - name: Cache compiled build
+#      id: cache-build
+#      uses: actions/cache@v3
+#      env:
+#        cache-name: cache-compiled-build
+#      with:
+#        path: _build
+#        key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+#        restore-keys: |
+#          ${{ runner.os }}-mix-${{ env.cache-name }}-
 
     # Step: Download project dependencies. If unchanged, uses
     # the cached version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+  1. Clean-up CI, Readme, and Docs.
+
 ## [0.3.0] 2024-03-30
 
    1. This release comes from an entirely new codebase: [awong-dev/jieba](https://github.com/awong-dev/jieba).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jieba
 
-![Build](https://github.com/awong-dev/jieba-rs/actions/workflows/elixir.yml/badge.svg)
+![Build](https://github.com/awong-dev/jieba/actions/workflows/elixir.yml/badge.svg)
 ![semver](https://img.shields.io/badge/semver-0.3.0-blue)
 
 ([Note for versions 0.2.0 and earlier](#0.2.0-and-earlier))

--- a/lib/jieba.ex
+++ b/lib/jieba.ex
@@ -432,6 +432,8 @@ defmodule Jieba do
   require the Jieba-RS project redesign the TFIDF interface so it takes
   `jieba` on the `extract_keyword()` method and not as in the `new()` method.
 
+  See https://github.com/messense/jieba-rs/issues/99 for details.
+
   Returns { :ok,
             [ %Jieba.Keyword{keyword: "北京烤鸭", weight: 1.3904870323222223},
               %Jieba.Keyword{keyword: "纽约", weight: 1.121759684755},
@@ -498,6 +500,8 @@ defmodule Jieba do
   shared with a ResourceARC and a Mutex. To do this more properly would
   require the Jieba-RS project redesign the TextRank interface so it takes
   `jieba` on the `extract_keyword()` method and not as in the `new()` method.
+
+  See https://github.com/messense/jieba-rs/issues/99 for details.
 
   Returns { :ok,
             [


### PR DESCRIPTION
The compile caching seems to be incorrectly forgetting to rebuild rustler binaries if source files are not touched. This causes the CI to spuriously fail.

Also fix the CI badge URL and add in link to the jieba_rs bug for TFIDF/TextRank API weirdness.