### PR TITLE
Workaround: silence non_local_definitions on rustler 0.31 resource! m…

### DIFF
--- a/native/rustler_jieba/src/lib.rs
+++ b/native/rustler_jieba/src/lib.rs
@@ -65,6 +65,11 @@ struct JiebaToken {
     pub start: usize,
 }
 
+// rustler 0.31's `resource!` macro emits a non-local `impl` block, which Rust
+// 1.80+ flags via the `non_local_definitions` lint. CI runs clippy with
+// `-Dwarnings`, so we silence it locally. Removable once we upgrade to
+// rustler >= 0.32, which replaces this macro with `env.register::<T>()`.
+#[allow(non_local_definitions)]
 fn on_load(env: Env, _term: Term) -> bool {
     rustler::resource!(JiebaResource, env);
     true


### PR DESCRIPTION
…acro

The `rustler::resource!` macro in rustler 0.31 emits a non-local `impl` block that Rust 1.80+ flags via the `non_local_definitions` lint. CI runs `cargo clippy -- -Dwarnings`, which promotes the warning to an error and breaks the build on current toolchains.

This commit only suppresses the lint on `on_load` to unbreak CI. The real fix is to upgrade rustler to >= 0.32, which replaces the macro with `env.register::<T>()` and resolves the underlying issue. That upgrade will land in a follow-up PR — at which point the `#[allow(non_local_definitions)]` and this comment can be removed.