### PR TITLE
Release hygiene, CI housekeeping, updating versions. No API changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     name: Test on OTP ${{matrix.otp_version}} / Elixir ${{matrix.elixir_version}}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
     tags:
       - "*"
 
+# softprops/action-gh-release attaches build artifacts to the GitHub Release,
+# which requires write access to the repo's release contents.
+permissions:
+  contents: write
+
 jobs:
   build_release:
     name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ on:
 permissions:
   contents: write
 
+# Note: cancel-in-progress is deliberately false so a tag push that kicks off
+# a real release is never interrupted by a later push to main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build_release:
     name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,16 @@ jobs:
       matrix:
         nif: ["2.15"]
         job:
-          - { target: aarch64-apple-darwin, os: macos-11 }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
-          - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
-          - { target: arm-unknown-linux-gnueabihf, os: ubuntu-20.04, use-cross: true }
-          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
-          - { target: x86_64-apple-darwin, os: macos-11 }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019 }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019 }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
+          - { target: aarch64-apple-darwin, os: macos-14 }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true }
+          - { target: arm-unknown-linux-gnueabihf, os: ubuntu-22.04, use-cross: true }
+          - { target: riscv64gc-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true }
+          - { target: x86_64-apple-darwin, os: macos-13 }
+          - { target: x86_64-pc-windows-gnu, os: windows-2022 }
+          - { target: x86_64-pc-windows-msvc, os: windows-2022 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-22.04, use-cross: true }
 
     steps:
       - name: Checkout source code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
   build_release:
     name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -23,6 +23,7 @@ jobs:
   lint-rust:
     name: Lint Rust
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         manifest:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -12,6 +12,9 @@ on:
     paths:
       - 'native/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint-rust:
     name: Lint Rust

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -34,7 +34,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            native/ex_tokenizers/target/
+            native/rustler_jieba/target/
             priv/native/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-rust:
     name: Lint Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Unreleased
   Nothing.
 
+## [0.3.2] 2026-04-21
+Loosen versioning for `rustler` and `rustler_precompiled` to only
+specify the minor versions instead of the patch versions.
+
+Update CI to newer script versions.
+
 ## [0.3.1] 2024-03-31
 Clean-up CI, Readme, and Docs. Precompile binaries for common platforms.
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Jieba.MixProject do
 
   @source_url "https://github.com/awong-dev/jieba"
   # Note, release.yml uses a regexp to parse the version from this line.
-  @version "0.3.1"
+  @version "0.3.2"
 
   def project do
     [
@@ -29,8 +29,8 @@ defmodule Jieba.MixProject do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:rustler, "~> 0.31.0", runtime: false},
-      {:rustler_precompiled, "~> 0.7.1"}
+      {:rustler, "~> 0.31", runtime: false},
+      {:rustler_precompiled, "~> 0.7"}
     ]
   end
 


### PR DESCRIPTION
The last release was a long time ago and many of the build platforms are no longer supported.

This is a minimal update to produce new binaries before updating to newer rustler versions and bumping to 0.4.0